### PR TITLE
Fix TypeScript type errors and eliminate any

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -88,22 +88,20 @@ export async function POST(req: Request) {
 
     // Normalize output to an array of URLs
     let urls: string[] = [];
-    // Common fal output shape
-    const anyResult = result as any;
-    if (Array.isArray(anyResult?.images)) {
-      urls = anyResult.images
-        .map((img: any) => (typeof img === "string" ? img : img?.url))
-        .filter(Boolean);
-    } else if (anyResult?.image) {
-      const img = anyResult.image;
-      const u = typeof img === "string" ? img : img?.url;
+    if (Array.isArray(result.images)) {
+      urls = result.images
+        .map((img) => (typeof img === "string" ? img : img.url))
+        .filter((u): u is string => Boolean(u));
+    } else if (result.image) {
+      const img = result.image;
+      const u = typeof img === "string" ? img : img.url;
       if (u) urls = [u];
     }
 
     return new Response(
       JSON.stringify({
-        images: urls.map((u: string) => ({ url: u })),
-        seed: anyResult?.seed ?? seed,
+        images: urls.map((u) => ({ url: u })),
+        seed: result.seed ?? seed,
         width,
         height,
       }),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -146,11 +146,18 @@ export default function Home() {
       });
 
       if (!res.ok) throw new Error("Generation failed");
-      const data = await res.json();
-      const urls: string[] = (data?.images ?? []).map((i: any) => i?.url).filter(Boolean);
-      const baseSeed = data?.seed ?? seed;
-      const w = data?.width ?? undefined;
-      const h = data?.height ?? undefined;
+      const data: {
+        images?: Array<{ url?: string | null }>;
+        seed?: number;
+        width?: number;
+        height?: number;
+      } = await res.json();
+      const urls: string[] = (data.images ?? [])
+        .map((i) => i.url)
+        .filter((u): u is string => Boolean(u));
+      const baseSeed = data.seed ?? seed;
+      const w = data.width ?? undefined;
+      const h = data.height ?? undefined;
 
       const batch: Render[] = urls.map((u, i) => ({
         id: `${Date.now()}-${i}`,
@@ -161,7 +168,7 @@ export default function Home() {
         url: u,
       }));
 
-      // If for any reason no URLs came back, keep a graceful fallback
+      // If no URLs came back, keep a graceful fallback
       const finalBatch = batch.length > 0
         ? batch
         : Array.from({ length: 4 }).map((_, i) => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,45 @@
+declare module "@fal-ai/serverless-client" {
+  export function config(options: { credentials?: string }): void;
+
+  interface ImageData {
+    url: string;
+  }
+
+  interface RunResult {
+    images?: Array<string | ImageData>;
+    image?: string | ImageData;
+    seed?: number;
+  }
+
+  export function run(
+    model: string,
+    params: { input: Record<string, unknown> }
+  ): Promise<RunResult>;
+}
+
+declare module "uploadthing/server" {
+  interface UploadInfo {
+    url?: string;
+    ufsUrl?: string;
+  }
+
+  type UploadResult =
+    | UploadInfo[]
+    | { data?: UploadInfo[] | UploadInfo };
+
+  export class UTApi {
+    uploadFiles(files: (Blob | File)[]): Promise<UploadResult>;
+  }
+}
+
+declare module "@libsql/client" {
+  export interface ResultSet {
+    rows: Record<string, unknown>[];
+  }
+
+  export interface Client {
+    execute(query: string | { sql: string; args?: unknown[] }): Promise<ResultSet>;
+  }
+
+  export function createClient(config: { url: string; authToken: string }): Client;
+}


### PR DESCRIPTION
## Summary
- add module declarations for `@fal-ai/serverless-client`, `uploadthing/server`, and `@libsql/client`
- remove `any` usage in generation and history API routes
- type frontend generation response and clean up URL handling

## Testing
- `npx tsc --noEmit`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68afb6a2d1548328b7ae94995e961929