### PR TITLE
refactor: remove any types

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -147,7 +147,12 @@ export default function Home() {
 
       if (!res.ok) throw new Error("Generation failed");
       const data = await res.json();
-      const urls: string[] = (data?.images ?? []).map((i: any) => i?.url).filter(Boolean);
+      const images: Array<{ url: string } | string> = Array.isArray(data?.images)
+        ? data.images
+        : [];
+      const urls: string[] = images
+        .map((img) => (typeof img === "string" ? img : img.url))
+        .filter((u): u is string => Boolean(u));
       const baseSeed = data?.seed ?? seed;
       const w = data?.width ?? undefined;
       const h = data?.height ?? undefined;

--- a/src/types/external.d.ts
+++ b/src/types/external.d.ts
@@ -1,0 +1,24 @@
+declare module "@fal-ai/serverless-client" {
+  export function config(opts: { credentials?: string }): void;
+  export function run<T>(model: string, params: unknown): Promise<T>;
+}
+
+declare module "uploadthing/server" {
+  export class UTApi {
+    uploadFiles(files: File[]): Promise<
+      Array<{ url?: string; ufsUrl?: string }> | { data?: Array<{ url?: string; ufsUrl?: string }> }
+    >;
+  }
+}
+
+declare module "@libsql/client" {
+  export interface ExecuteResult {
+    rows: Array<Record<string, unknown>>;
+  }
+  export interface Client {
+    execute(
+      params: string | { sql: string; args?: unknown[] | Record<string, unknown> }
+    ): Promise<ExecuteResult>;
+  }
+  export function createClient(config: { url: string; authToken?: string }): Client;
+}


### PR DESCRIPTION
## Summary
- define proper result interfaces for API routes
- avoid `any` usage by adding explicit types and Node `File` polyfill
- declare missing external modules for TypeScript

## Testing
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afb6900cf48328a8fb9d36a3cc29f4